### PR TITLE
Create public file importing

### DIFF
--- a/src/modules/imports/import.rs
+++ b/src/modules/imports/import.rs
@@ -15,6 +15,7 @@ pub struct Import {
     token_import: Option<Token>,
     token_path: Option<Token>,
     is_all: bool,
+    is_pub: bool,
     export_defs: Vec<(String, Option<String>, Option<Token>)>
 }
 
@@ -28,8 +29,8 @@ impl Import {
                     None => continue,
                 }
             }
-            // This function should not be furher exported
-            fun.is_public = false;
+            // Determine if imported functions should be exported further
+            fun.is_public = self.is_pub;
             let name = fun.name.clone();
             if meta.add_fun_declaration_existing(fun).is_none() {
                 return error!(meta, self.token_import.clone() => {
@@ -101,11 +102,13 @@ impl SyntaxModule<ParserMetadata> for Import {
             token_import: None,
             token_path: None,
             is_all: false,
+            is_pub: false,
             export_defs: vec![]
         }
     }
 
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
+        self.is_pub = token(meta, "pub").is_ok();
         self.token_import = meta.get_current_token();
         token(meta, "import")?;
         if !meta.is_global_scope() {

--- a/src/utils/metadata/parser.rs
+++ b/src/utils/metadata/parser.rs
@@ -111,6 +111,10 @@ impl ParserMetadata {
     /// Adds a function declaration that that was already parsed - this function is probably imported
     pub fn add_fun_declaration_existing(&mut self, fun: FunctionDecl) -> Option<usize> {
         let global_id = self.gen_fun_id();
+        // Add the function to the public function list
+        if fun.is_public {
+            self.context.pub_funs.push(fun.clone());
+        }
         // Add the function to the current scope
         let scope = self.context.scopes.last_mut().unwrap();
         scope.add_fun(fun).then(|| global_id)


### PR DESCRIPTION
### Create a `pub import` syntax

```
import { input } from 'test4.ab'
// or `import * from 'test4.ab'`
input()
```

When

_test4.ab_
```
pub import { input } from 'std'
```