### PR TITLE
A83 Add chain modifiers for function invocations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,5 +18,3 @@ jobs:
       run: cargo build --verbose
     - name: Run validity tests
       run: cargo test validity --verbose
-    - name: Run performance tests
-      run: cargo test performance --verbose

--- a/src/modules/command/modifier.rs
+++ b/src/modules/command/modifier.rs
@@ -81,8 +81,8 @@ impl SyntaxModule<ParserMetadata> for CommandModifier {
         swap(&mut self.is_unsafe, &mut meta.context.is_unsafe_ctx);
         if self.is_expr {
             syntax(meta, &mut *self.expr)?;
-            if !matches!(self.expr.value, Some(ExprType::CommandExpr(_))) {
-                return error!(meta, tok, format!("Expected command expression, after '{sequence}' command modifiers."));
+            if !matches!(self.expr.value, Some(ExprType::CommandExpr(_) | ExprType::FunctionInvocation(_))) {
+                return error!(meta, tok, format!("Expected command or function call, after '{sequence}' command modifiers."));
             }
         } else {
             match token(meta, "{") {
@@ -104,7 +104,7 @@ impl SyntaxModule<ParserMetadata> for CommandModifier {
 
 impl TranslateModule for CommandModifier {
     fn translate(&self, meta: &mut TranslateMetadata) -> String {
-        meta.silenced = true;
+        meta.silenced = self.is_silent;
         let result = if self.is_expr {
             return self.expr.translate(meta)
         } else {

--- a/src/modules/condition/failed.rs
+++ b/src/modules/condition/failed.rs
@@ -6,7 +6,7 @@ use crate::utils::metadata::{ParserMetadata, TranslateMetadata};
 
 #[derive(Debug, Clone)]
 pub struct Failed {
-    is_parsed: bool,
+    pub is_parsed: bool,
     is_question_mark: bool,
     is_main: bool,
     block: Box<Block>
@@ -27,6 +27,8 @@ impl SyntaxModule<ParserMetadata> for Failed {
     fn parse(&mut self, meta: &mut ParserMetadata) -> SyntaxResult {
         let tok = meta.get_current_token();
         if meta.context.is_unsafe_ctx {
+            self.is_main = meta.context.is_main_ctx;
+            self.is_parsed = true;
             return Ok(());
         }
         if let Ok(_) = token(meta, "?") {

--- a/src/tests/validity.rs
+++ b/src/tests/validity.rs
@@ -780,3 +780,40 @@ fn chained_modifiers() {
     ";
     test_amber!(code, "Hello World");
 }
+
+#[test]
+fn chained_modifiers_commands() {
+    let code = "
+        unsafe silent {
+            echo 'Hello World'
+            $non-existant command$
+        }
+        // Test for expression
+        let _ = silent unsafe $non-existant command$
+        // Test for single statement
+        silent unsafe $non-existant command$
+    ";
+    test_amber!(code, "Hello World");
+}
+
+#[test]
+fn chained_modifiers_functions() {
+    let code = "
+        fun foo(a) {
+            echo a
+            fail 1
+        }
+
+        fun bar() {
+            echo 'this should not appear'
+        }
+        
+        unsafe foo('one')
+        unsafe {
+            foo('two')
+        }
+        unsafe silent foo('this should not appear')
+        silent bar()
+    ";
+    test_amber!(code, "one\ntwo");
+}


### PR DESCRIPTION
Add modifiers for function calls that can call them unsafely or silently.

```
unsafe {
  failable_foo()
}
// Or
unsafe failable_foo()
// Or even
silent unsafe failable_foo()
```