### PR TITLE
A91 Import error when imported symbol that does not exist

### DIFF
--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -86,7 +86,7 @@ pub fun sum(list: [Num]): Num {
     return unsafe $echo "{list}" | awk '\{s=0; for (i=1; i<=NF; i++) s+=\$i; print s}'$ as Num
 }
 
-pub fun hasFailed(command: Text): Bool {
+pub fun has_failed(command: Text): Bool {
     unsafe silent $eval {command}$
     return status != 0
 }


### PR DESCRIPTION
Currently, a user can import a function that does not exist in another file but cannot use it. Ensure that importing non-existent functions yields an error.