### PR TITLE
change the name of the AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ curl -s "https://raw.githubusercontent.com/Ph0enixKM/AmberNative/master/setup/in
 #### Via a package manager
 Amber is packaged in the following distros:
 
-Arch (AUR) - `amber-bash`
+Arch (AUR) - `amber-bash-bin`
 
 ### Windows support
 As windows does not come with bash installed it makes no sense to support it. Please install WSL 2 on your windows machine and install Linux version of Amber compiler inside.


### PR DESCRIPTION
the AUR package name has changed to comply with its [submission guidelines](https://wiki.archlinux.org/title/AUR_submission_guidelines). the old name should still work, but will be confusing