### PR TITLE
quote retuned text values

### DIFF
--- a/src/modules/function/invocation.rs
+++ b/src/modules/function/invocation.rs
@@ -97,9 +97,11 @@ impl SyntaxModule<ParserMetadata> for FunctionInvocation {
 impl FunctionInvocation {
     fn get_variable(&self, meta: &TranslateMetadata, name: &str, dollar_override: bool) -> String {
         let dollar = dollar_override.then_some("$").unwrap_or_else(|| meta.gen_dollar());
+        let quote = meta.gen_quote();
         if matches!(self.kind, Type::Array(_)) {
-            let quote = meta.gen_quote();
             format!("{quote}{dollar}{{{name}[@]}}{quote}")
+        } else if matches!(self.kind, Type::Text) {
+            format!("{quote}{dollar}{{{name}}}{quote}")
         } else {
             format!("{dollar}{name}")
         }

--- a/src/tests/validity.rs
+++ b/src/tests/validity.rs
@@ -760,6 +760,10 @@ fn test_std_library() {
             loop word in words(\"hello   world ciao     mondo\") {
                 echo word
             }
+            // Split a joined string into a list of string
+            loop word in words(join([\"hello\", \"world\"], \" \")) {
+                echo word
+            }
             // Join a list of strings into a string
             echo join(split(\"hello world\", \"l\"), \"l\")
             // Transform string into a lowercase string
@@ -798,6 +802,8 @@ fn test_std_library() {
         "world",
         "ciao",
         "mondo",
+        "hello",
+        "world",
         "hello world",
         "hello world",
         "HELLO WORLD",
@@ -1120,5 +1126,5 @@ fn variable_ref_function_invocation() {
         unsafe foo(a)
         echo a
     ";
-    test_amber!(code, "sram");
+    test_amber!(code, "\"sram\"");
 }


### PR DESCRIPTION
Quote returned text values to prevent word splitting.

reproduction script 
```
import { words, join } from "std"

main(args) {
  echo words(join(["hello", "world"], " "))
}
```

before
```
hello
```

after
```
hello world
```

ref. https://www.shellcheck.net/wiki/SC2086