### PR TITLE
Replace '$(echo /bin/bash)' in install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Make sure that the operating system meets the following prerequisites
 
 #### system-wide install
 ```bash
-curl -s "https://raw.githubusercontent.com/Ph0enixKM/AmberNative/master/setup/install.sh" | $(echo /bin/bash)
+curl -s "https://raw.githubusercontent.com/Ph0enixKM/AmberNative/master/setup/install.sh" | /bin/bash
 ```
 
 #### local-user install
 ```bash
-curl -s "https://raw.githubusercontent.com/Ph0enixKM/AmberNative/master/setup/install.sh" | $(echo /bin/bash) -s -- --user
+curl -s "https://raw.githubusercontent.com/Ph0enixKM/AmberNative/master/setup/install.sh" | /bin/bash -s -- --user
 ```
 
 #### Via a package manager


### PR DESCRIPTION
Now that the command is [no longer using `$SHELL` on the right side of the pipe](https://github.com/Ph0enixKM/Amber/commit/3f137655dd34e27304a6636a360144c76a3bc1c3#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24), there's no need to over-complicate things.