### PR TITLE
trailing comma in arrays

### DIFF
--- a/src/modules/expression/literal/array.rs
+++ b/src/modules/expression/literal/array.rs
@@ -50,6 +50,9 @@ impl SyntaxModule<ParserMetadata> for Array {
                     if token(meta, "[").is_ok() {
                         return error!(meta, tok, "Arrays cannot be nested due to the Bash limitations")
                     }
+                    if token(meta, "]").is_ok() {
+                        break;
+                    }
                     // Parse array value
                     let mut value = Expr::new();
                     syntax(meta, &mut value)?;

--- a/src/tests/validity.rs
+++ b/src/tests/validity.rs
@@ -535,6 +535,15 @@ fn array_init() {
 }
 
 #[test]
+fn array_init_with_trailing_comma() {
+    let code = "
+        let a = [1, 2, 3, 4, 5,]
+        echo a
+    ";
+    test_amber!(code, "1 2 3 4 5");
+}
+
+#[test]
 fn array_assign() {
     let code = "
         let a = [1, 2, 3, 4, 5]


### PR DESCRIPTION

I would like Amber to accept trailing commas in arrays, but I'm not sure if that is a good choice for Amber.

script
```
let array = [
    1,
    2,
    3,
]

loop a in array {
    echo a
}
```

output
```
1
2
3
```

script
```
let array = [,]

loop a in array {
    echo a
}
```

output
```
 ERROR 
Expected expression
at test.ab:1:14


1| let array = [,]
2| 
```

script
```
let array = [1,2,3,,]

loop a in array {
    echo a
}
```
output
```
 ERROR 
Expected expression
at test.ab:1:20


1| let array = [1,2,3,,]
2| 
```

script

```
let array = []

loop a in array {
    echo a
}
```

output
```
 ERROR 
Expected array type or value before ']'
at test.ab:1:14


Eg. insert 'Num' for empty array or '1, 2, 3' for array with values

1| let array = []
2| 
```