### PR TITLE
Apply release optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ clap = { version = "4.4.18", features = ["derive"] }
 debug = true
 strip = true
 lto = true
-opt-level = "z"
+opt-level = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ clap = { version = "4.4.18", features = ["derive"] }
 
 [profile.release]
 debug = true
+strip = true
+lto = true
+opt-level = "z"


### PR DESCRIPTION
These optimizations have no effect on program behaviour.

Size difference:
`23883448 bytes` on master -> `1128896 bytes` on this branch (~23MB -> 1MB)

Closes #130 