### PR TITLE
Fix the `includes` function

### DIFF
--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -121,6 +121,10 @@ pub fun exit(code: Num): Null {
 }
 
 pub fun includes(arr, value) {
-    unsafe $[[ "\$\{{nameof arr}[@]}" =~ "{value}" ]]$
-    return status == 0
+    loop v in arr {
+        if v == value {
+            return true
+        }
+    }
+    return false
 }


### PR DESCRIPTION
Resolve #118 

In this commit, `includes` iterates over an array and returns `true` if it finds a match. Additionally, I have added more test cases for the `includes` function.

I guess this commit introduces a breaking change to the `includes` function.


#### before

script
```
import { includes } from "std"

let array = [1, 2]

echo includes(array, 1)
echo includes(array, "1")

```

```
1
1
```

### after

```
Cannot compare two values of different types 'Num' == 'Text'
at [standard library]:125:14
in test.ab:1:1
```
