### PR TITLE
hotfix: Fix opt-level in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ tempfile = "3.10.1"
 [profile.release]
 strip = true
 lto = true
-opt-level = "3"
+opt-level = 3


### PR DESCRIPTION
apparently its got to be an integer, not a string