### PR TITLE
🐞 Fix the std trim function

### DIFF
--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -62,16 +62,16 @@ pub fun join(list: [Text], delimiter: Text): Text {
     return unsafe $IFS="{delimiter}" ; echo "\$\{{nameof list}[*]}"$
 }
 
-pub fun trim(text: Text): Text {
-    return unsafe $echo "{text}" | xargs$
-}
-
 pub fun trim_left(text: Text): Text {
     return unsafe $echo "{text}" | sed -e 's/^[[:space:]]*//'$
 }
 
 pub fun trim_right(text: Text): Text {
     return unsafe $echo "{text}" | sed -e 's/[[:space:]]*\$//'$
+}
+
+pub fun trim(text: Text): Text {
+    return trim_left(trim_right(text))
 }
 
 pub fun lower(text: Text): Text {

--- a/src/tests/stdlib.rs
+++ b/src/tests/stdlib.rs
@@ -193,10 +193,10 @@ fn trim() {
     let code = "
         import * from \"std\"
         main {
-            echo trim(\"  hello world  \")
+            echo trim(\"  hello   world  \")
         }
     ";
-    test_amber!(code, "hello world")
+    test_amber!(code, "hello   world")
 }
 
 #[test]
@@ -204,10 +204,10 @@ fn trim_left() {
     let code = "
         import * from \"std\"
         main {
-            echo trim_left(\"  hello world  \")
+            echo trim_left(\"  hello   world  \")
         }
     ";
-    test_amber!(code, "hello world  ")
+    test_amber!(code, "hello   world  ")
 }
 
 #[test]
@@ -215,10 +215,10 @@ fn trim_right() {
     let code = "
         import * from \"std\"
         main {
-            echo trim_right(\"  hello world  \")
+            echo trim_right(\"  hello   world  \")
         }
     ";
-    test_amber!(code, "  hello world")
+    test_amber!(code, "  hello   world")
 }
 
 #[test]
@@ -418,4 +418,3 @@ fn lines() {
     ";
     test_amber!(code, "line: hello\nline: world")
 }
-


### PR DESCRIPTION
Fixes the incorrect behavior of `trim` function. Tests have been adjusted to account for that edge case where spaces are removed between words as well.