### PR TITLE
🐞 Fractions without leading zero do not parse correctly

### DIFF
--- a/src/modules/expression/literal/number.rs
+++ b/src/modules/expression/literal/number.rs
@@ -26,12 +26,12 @@ impl SyntaxModule<ParserMetadata> for Number {
         if let Ok(sym) = token(meta, "-") {
             self.value.push_str(&sym);
         }
-        if let Ok(value) = number(meta, vec![]) {
+        if let Ok(value) = integer(meta, vec![]) {
             self.value.push_str(&value);
         }
         if let Ok(sym) = token(meta, ".") {
             self.value.push_str(&sym);
-            self.value.push_str(&number(meta, vec![])?);
+            self.value.push_str(&integer(meta, vec![])?);
         }
         if self.value.is_empty() {
             return Err(Failure::Quiet(PositionInfo::from_metadata(meta)))

--- a/src/tests/validity.rs
+++ b/src/tests/validity.rs
@@ -100,6 +100,16 @@ fn very_complex_arithmetic() {
 }
 
 #[test]
+fn fractions_with_no_leading_zero() {
+    let code = "
+        let a = .2
+        let b = .1
+        echo a + b
+    ";
+    test_amber!(code, ".3");
+}
+
+#[test]
 fn parenthesis() {
     let code = "
         let x = 21


### PR DESCRIPTION
Heraclitus method `number` parses either integer or float. Changed that to `integer` which parses a string of digits for where we want to parse the part before and after the dot. Since we tokenize separately symbols `-` and `.` we have to define our own strategy of parsing numbers. The dot symbol even if not used right now - it will be useful in the future for parsing dictionary accessors like `dict.name`.