### PR TITLE
split multiline strings

### DIFF
--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -44,7 +44,7 @@ pub fun file_append(path, content) {
 
 pub fun split(text: Text, delimiter: Text): [Text] {
     let result = [Text]
-    unsafe $IFS="{delimiter}" read -ra {nameof result} <<< "\${nameof text}"$
+    unsafe $IFS="{delimiter}" read -rd '' -a {nameof result} < <(printf %s "\${nameof text}")$
     return result
 }
 

--- a/src/tests/stdlib.rs
+++ b/src/tests/stdlib.rs
@@ -178,6 +178,18 @@ fn split() {
 }
 
 #[test]
+fn split_multiline() {
+    let code = "
+        import * from \"std\"
+        main {
+            let array = split(\"apple,ban\nana,cherry\", \",\")
+            echo array
+        }
+    ";
+    test_amber!(code, "apple ban\nana cherry")
+}
+
+#[test]
 fn join() {
     let code = "
         import * from \"std\"


### PR DESCRIPTION
I'd like the `split` function to work with multiline strings, similar to the `lines` function. In this commit, the split function reads the text until it encounters a NULL character.

And I use `printf` to pass the text instead of a here document to avoid the extra newline.

```sh
$ cat < <(printf %s "Hello, world") | od -c
0000000   H   e   l   l   o   ,       w   o   r   l   d
0000014
$ cat <<< "Hello, world" | od -c
0000000   H   e   l   l   o   ,       w   o   r   l   d  \n
0000015
```
script

```
import { words } from "std"

let str = "abd\txd e\nfgh:i"
loop word in words(str) {
  echo "==="
  echo word
  echo "==="
}
```

heredoc
`unsafe $IFS="{delimiter}" read -rd '' -a {nameof result} <<<"\${nameof text}"$`

```
===
abd	xd
===
===
e
fgh:i

===

```


printf
```
===
abd	xd
===
===
e
fgh:i
===
```
