### PR TITLE
feat(install): improved symbolic link

### DIFF
--- a/setup/install.ab
+++ b/setup/install.ab
@@ -99,7 +99,7 @@ main(args) {
         exit(1)
     }
 
-    // Remove the archive
+    // Delete the archive
     ${sudo} rm {place}/{archive}$ failed {
         echo "Failed to remove downloaded archive at {place}/{archive}"
         exit(1)
@@ -109,6 +109,13 @@ main(args) {
     ${sudo} chmod +x "{place}/{target}"$ failed {
         echo "Failed to give permissions to execute amber."
         echo "Please make sure that root user can access {place} directory."
+        exit(1)
+    }
+
+    // Delete the previous symbolic link
+    ${sudo} rm "{bins_folder}/{target}" failed {
+        echo "Failed to remove the previous amber symbol link."
+        echo "Please make sure that root user can access /usr/local/bin directory."
         exit(1)
     }
 

--- a/setup/install.ab
+++ b/setup/install.ab
@@ -116,7 +116,7 @@ main(args) {
     if file_exist("{bins_folder}/{target}") {
         ${sudo} rm "{bins_folder}/{target}" failed {
             echo "Failed to remove the previous amber symbol link."
-            echo "Please make sure that root user can access /usr/local/bin directory."
+            echo "Please make sure that root user can access {bins_folder} directory."
             exit(1)
         }
     }

--- a/setup/install.ab
+++ b/setup/install.ab
@@ -113,10 +113,12 @@ main(args) {
     }
 
     // Delete the previous symbolic link
-    ${sudo} rm "{bins_folder}/{target}" failed {
-        echo "Failed to remove the previous amber symbol link."
-        echo "Please make sure that root user can access /usr/local/bin directory."
-        exit(1)
+    if file_exist("{bins_folder}/{target}") {
+        ${sudo} rm "{bins_folder}/{target}" failed {
+            echo "Failed to remove the previous amber symbol link."
+            echo "Please make sure that root user can access /usr/local/bin directory."
+            exit(1)
+        }
     }
 
     // Create amber symbol link

--- a/setup/install.ab
+++ b/setup/install.ab
@@ -124,7 +124,7 @@ main(args) {
     // Create amber symbol link
     ${sudo} ln -s "{place}/{target}" "{bins_folder}/{target}"$ failed {
         echo "Failed to create amber symbol link."
-        echo "Please make sure that root user can access /usr/local/bin directory."
+        echo "Please make sure that root user can access {bins_folder} directory."
         exit(1)
     }
 


### PR DESCRIPTION
So if you already installed Amber you get an error to remove the previous install folder.

You did but you get an error about the symbolic link that already exists.

So it is enough to remove the symbolic link to regenerate everything.