### PR TITLE
fix(ci): cargo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,15 +1,15 @@
-name: Rust
+name: Cargo Build & Test
 
 on:
-  pull_request_target:
-    branches:
-      - master
+  push:
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build_and_test:
+    name: Rust build and tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
* Remove the building of the snap package on every PR
* Execute the cargo build and tests from the PR and also from the push, before was executing always from the upstream `master`

Before:
![immagine](https://github.com/Ph0enixKM/Amber/assets/403283/daa25f21-9302-42a1-9f3c-771adc2bf80d)

After:
![immagine](https://github.com/Ph0enixKM/Amber/assets/403283/e18ff2fb-7555-48b9-956e-a0ddb706a466)
