### PR TITLE
support for optional arguments

### DIFF
--- a/src/utils/context.rs
+++ b/src/utils/context.rs
@@ -1,5 +1,6 @@
 use heraclitus_compiler::prelude::*;
 use std::collections::{HashMap, HashSet};
+use crate::modules::expression::expr::Expr;
 use crate::modules::types::Type;
 
 use super::{function_interface::FunctionInterface, cc_flags::CCFlags};
@@ -10,6 +11,7 @@ pub struct FunctionDecl {
     pub arg_names: Vec<String>,
     pub arg_types: Vec<Type>,
     pub arg_refs: Vec<bool>,
+    pub arg_optionals : Vec<Expr>,
     pub returns: Type,
     pub is_args_typed: bool,
     pub is_public: bool,
@@ -25,6 +27,7 @@ impl FunctionDecl {
             arg_names: self.arg_names,
             arg_types: self.arg_types,
             arg_refs: self.arg_refs,
+            arg_optionals: self.arg_optionals,
             returns: self.returns,
             is_public: self.is_public,
             is_failable: self.is_failable

--- a/src/utils/function_interface.rs
+++ b/src/utils/function_interface.rs
@@ -1,4 +1,5 @@
 use crate::modules::{types::Type, block::Block};
+use crate::modules::expression::expr::Expr;
 use super::{context::FunctionDecl, function_cache::FunctionInstance};
 
 
@@ -10,6 +11,7 @@ pub struct FunctionInterface {
     pub arg_names: Vec<String>,
     pub arg_types: Vec<Type>,
     pub arg_refs: Vec<bool>,
+    pub arg_optionals : Vec<Expr>,
     pub returns: Type,
     pub is_public: bool,
     pub is_failable: bool,
@@ -23,6 +25,7 @@ impl FunctionInterface {
             arg_names: self.arg_names,
             arg_types: self.arg_types,
             arg_refs: self.arg_refs,
+            arg_optionals: self.arg_optionals,
             returns: self.returns,
             is_args_typed,
             is_public: self.is_public,


### PR DESCRIPTION
added support for optional arguments. a regular argument cannot follow an optional argument, so something like

```
fun foo(arg1, arg2 = true, arg3){}
```
raises an error. It's during the parsing of an invocation that missing arguments in the invocation are replaced with the default arguments parsed during definition. Once we determine the location of the first missing argument, all the default arguments which follow are also passed to the invocation. This is why we can't interleave optional and non-optionals. 