### PR TITLE
Use `$(< file)` instead of `$(cat file)`

### DIFF
--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -31,7 +31,7 @@ pub fun file_exist(path) {
 }
 
 pub fun file_read(path) {
-    return $cat "{path}"$?
+    return $< "{path}"$?
 }
 
 pub fun file_write(path, content) {


### PR DESCRIPTION
I think it's better to `use` `$(< file)` instead of `$(cat file)`

ref. https://www.gnu.org/software/bash/manual/html_node/Command-Substitution.html
> `The command substitution $(cat file) can be replaced by the equivalent but faster $(< file).`