### PR TITLE
fix(std): download and curl

### DIFF
--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -174,7 +174,7 @@ pub fun switch_user_permission(user: Text, path: Text): Bool {
 pub fun download(url: Text, path: Text): Bool {
     if {
         is_command("curl") {
-            unsafe $curl -o "{path}" "{url}"$
+            unsafe $curl -L -o "{path}" "{url}"$
         }
         is_command("wget") {
             unsafe $wget "{url}" -P "{path}"$


### PR DESCRIPTION
Curl without the parameter doesn't follow the redirects automatically, the other commands instead do that natively.