### PR TITLE
Version Bump 0.3.4-alpha + minor stdlib fix on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "amber"
-version = "0.3.3-alpha"
+version = "0.3.4-alpha"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amber"
-version = "0.3.3-alpha"
+version = "0.3.4-alpha"
 edition = "2021"
 repository = "https://github.com/Ph0enixKM/Amber"
 

--- a/src/std/main.ab
+++ b/src/std/main.ab
@@ -256,7 +256,7 @@ pub fun shell_constant_get(name: Text): Text {
 }
 
 pub fun shell_var_set(name: Text, val: Text): Null {
-    $declare -g \${nameof name}="\${nameof val}" 2> /dev/null$?
+    $export \${nameof name}="\${nameof val}" 2> /dev/null$?
 }
 
 pub fun shell_var_get(name: Text): Text {

--- a/src/tests/stdlib/shell_var_get.ab
+++ b/src/tests/stdlib/shell_var_get.ab
@@ -1,5 +1,5 @@
 import * from "std"
 main {
-    unsafe $declare -g test_shell_var_get="Hello Amber!"$
+    unsafe $export test_shell_var_get="Hello Amber!"$
     echo unsafe shell_var_get("test_shell_var_get")
 }


### PR DESCRIPTION
Bumping Amber version to 0.3.4-alpha and fixes error on macOS where declare -g does not exist (uses export instead)